### PR TITLE
make `device(NN::AbstractExplicitLayer)` instead of error

### DIFF
--- a/src/LuxDeviceUtils.jl
+++ b/src/LuxDeviceUtils.jl
@@ -242,8 +242,9 @@ for (dev) in (:CPU, :CUDA, :AMDGPU, :Metal)
             _isleaf(x) && return adapt($(ladaptor)(), x)
             return fmap(Base.Fix1(adapt, $(ladaptor)()), x; exclude=_isleaf)
         end
-        function (::$(ldev))(::LuxCore.AbstractExplicitLayer)
-            throw(ArgumentError("Lux layers are stateless and hence don't participate in device transfers. Apply this function on the parameters and states generated using `Lux.setup`."))
+        function (::$(ldev))(NN::LuxCore.AbstractExplicitLayer)
+            @warn "Lux layers are stateless and hence don't participate in device transfers. Apply this function on the parameters and states generated using `Lux.setup`." maxlog = 1
+            return NN
         end
     end
 end

--- a/src/LuxDeviceUtils.jl
+++ b/src/LuxDeviceUtils.jl
@@ -243,7 +243,7 @@ for (dev) in (:CPU, :CUDA, :AMDGPU, :Metal)
             return fmap(Base.Fix1(adapt, $(ladaptor)()), x; exclude=_isleaf)
         end
         function (::$(ldev))(NN::LuxCore.AbstractExplicitLayer)
-            @warn "Lux layers are stateless and hence don't participate in device transfers. Apply this function on the parameters and states generated using `Lux.setup`." maxlog = 1
+            @warn "Lux layers are stateless and hence don't participate in device transfers. Apply this function on the parameters and states generated using `Lux.setup`." maxlog=1
             return NN
         end
     end


### PR DESCRIPTION
close https://github.com/LuxDL/LuxDeviceUtils.jl/issues/24