### PR TITLE
Update AMDGPU RNG

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxDeviceUtils"
 uuid = "34f89e08-e1d5-43b4-8944-0b49ac560553"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.1.24"
+version = "0.1.25"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/LuxDeviceUtilsAMDGPUExt.jl
+++ b/ext/LuxDeviceUtilsAMDGPUExt.jl
@@ -43,7 +43,7 @@ end
 LuxDeviceUtils._get_device_id(dev::LuxAMDGPUDevice) = AMDGPU.device_id(dev.device)
 
 # Default RNG
-LuxDeviceUtils.default_device_rng(::LuxAMDGPUDevice) = AMDGPU.rocrand_rng()
+LuxDeviceUtils.default_device_rng(::LuxAMDGPUDevice) = AMDGPU.gpuarrays_rng()
 
 # Query Device from Array
 function LuxDeviceUtils.get_device(x::AMDGPU.AnyROCArray)

--- a/test/amdgpu.jl
+++ b/test/amdgpu.jl
@@ -41,7 +41,7 @@ using FillArrays, Zygote  # Extensions
 
     device = gpu_device()
     aType = LuxDeviceUtils.functional(LuxAMDGPUDevice) ? ROCArray : Array
-    rngType = LuxDeviceUtils.functional(LuxAMDGPUDevice) ? AMDGPU.rocRAND.RNG :
+    rngType = LuxDeviceUtils.functional(LuxAMDGPUDevice) ? AMDGPU.GPUArrays.RNG :
               Random.AbstractRNG
 
     ps_xpu = ps |> device


### PR DESCRIPTION
Using `rocrand_rng` doesn't let us do `deepcopy`, which makes `replicate` really unhappy.