### PR TITLE
chore: backport fixes/changes to `v0.1.*`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxDeviceUtils"
 uuid = "34f89e08-e1d5-43b4-8944-0b49ac560553"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.1.26"
+version = "0.1.27"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -41,7 +41,7 @@ LuxDeviceUtilsZygoteExt = "Zygote"
 LuxDeviceUtilsoneAPIExt = ["GPUArrays", "oneAPI"]
 
 [compat]
-AMDGPU = "0.9.6"
+AMDGPU = "0.9.6, 1"
 Adapt = "4"
 Aqua = "0.8.4"
 ArrayInterface = "7.11"

--- a/test/amdgpu_tests.jl
+++ b/test/amdgpu_tests.jl
@@ -116,9 +116,6 @@ using FillArrays, Zygote  # Extensions
 
         return_val(x) = Val(get_device_type(x))  # If it is a compile time constant then type inference will work
         @test @inferred(return_val(ps)) isa Val{parameterless_type(typeof(device))}
-
-        return_val2(x) = Val(get_device(x))
-        @test_throws ErrorException @inferred(return_val2(ps))
     end
 end
 


### PR DESCRIPTION
Don't merge this.

We must backport fixes until `LuxDeviceUtils` is used inside `Lux`.